### PR TITLE
fix: Cannot parse ObjectIdentifier with empty value

### DIFF
--- a/src/BER.h
+++ b/src/BER.h
@@ -291,7 +291,11 @@ public:
 
     void setValue(const char *value) {
         // L, V
-        strncpy(_value, value, SIZE_OBJECTIDENTIFIER);
+        if (value == nullptr) {
+          _value[0] = 0;
+        } else {
+          strncpy(_value, value, SIZE_OBJECTIDENTIFIER);
+        }
         unsigned int index = 0;
         unsigned int subidentifier = 0;
         char *token = (char*) _value;


### PR DESCRIPTION
On `SequenceBER::decode`, there is a chance that new `ObjectIdentifierBER` is created with `nullptr`.
This causes panic by reading over prohibited area while executing `ObjectIdentifierBER.setValue`.
This PR fixes this problem.