### PR TITLE
Use IPAddress object instead of null pointer in IPAddressBER

### DIFF
--- a/src/BER.cpp
+++ b/src/BER.cpp
@@ -419,7 +419,7 @@ const uint32_t SequenceBER::decode(unsigned char *buffer) {
                     ber = new ObjectIdentifierBER(nullptr);
                     break;
                 case TYPE_IPADDRESS:
-                    ber = new IPAddressBER(nullptr);
+                    ber = new IPAddressBER(IPAddress());
                     break;
                 case TYPE_COUNTER32:
                     ber = new Counter32BER(0);


### PR DESCRIPTION
This MR aims to solve #9 , wherein it's described that the way `IPAddressBER` is initialized with a null pointer and is not compatible with the constructors provided by the `arduino-esp32` library.  

Here, we create an empty `IPAddress` object instead.  

This was tested using the `Agent.ino` example on the `ESP32-WROVER-E` to validate the changes, and an `STM32F103` (bluepill + w5500 module) to check that it's not breaking compatibility.  


Thanks,
Cyril