### PR TITLE
Fix length encoding

### DIFF
--- a/src/BER.h
+++ b/src/BER.h
@@ -571,10 +571,10 @@ public:
      */
     void encode(Stream &stream) {
         if (_length > 0x7F) {
-            stream.write(0x80 | _size);
+            stream.write(0x80 | (_size-1));
             unsigned int length = _length;
-            for (uint8_t index = 0; index < _size; ++index) {
-                stream.write(length >> ((_size - index - 1) << 3));
+            for (uint8_t index = 0; index < (_size-1); ++index) {
+                stream.write(static_cast<uint8_t>((length >> (((_size-1) - index - 1) << 3)) & 0xFF));
             }
         } else {
             stream.write(_length);
@@ -615,11 +615,11 @@ public:
     uint8_t* encode(uint8_t *buffer) {
         uint8_t *pointer = buffer;
         if (_length > 0x7F) {
-            *pointer = 0x80 | _size;
-            pointer += _size;
+            *pointer = 0x80 | (_size-1);
+            pointer += (_size-1);
             unsigned int value = _length;
-            for (uint8_t index = 0; index < _size; ++index) {
-                *pointer-- = value;
+            for (uint8_t index = 0; index < (_size-1); ++index) {
+                *pointer-- = static_cast<uint8_t>(value & 0xFF);
                 value >>= 8;
             }
         } else {

--- a/src/BER.h
+++ b/src/BER.h
@@ -571,7 +571,7 @@ public:
      */
     void encode(Stream &stream) {
         if (_length > 0x7F) {
-            stream.write(0x80 | (_size-1));
+            stream.write(0x80 | _size - 1);
             unsigned int length = _length;
             for (uint8_t index = 0; index < (_size-1); ++index) {
                 stream.write(static_cast<uint8_t>((length >> (((_size-1) - index - 1) << 3)) & 0xFF));

--- a/src/BER.h
+++ b/src/BER.h
@@ -616,8 +616,9 @@ public:
     uint8_t* encode(uint8_t *buffer) {
         uint8_t *pointer = buffer;
         if (_length > 0x7F) {
-            *pointer = 0x80 | (_size-1);
-            pointer += (_size-1);
+            *pointer = 0x80 | _size - 1;
+            pointer += _size - 1;
+
             unsigned int value = _length;
             for (uint8_t index = 0; index < (_size-1); ++index) {
                 *pointer-- = static_cast<uint8_t>(value & 0xFF);

--- a/src/BER.h
+++ b/src/BER.h
@@ -620,8 +620,8 @@ public:
             pointer += _size - 1;
 
             unsigned int value = _length;
-            for (uint8_t index = 0; index < (_size-1); ++index) {
-                *pointer-- = static_cast<uint8_t>(value & 0xFF);
+            for (uint8_t index = 0; index < _size - 1; ++index) {
+                *pointer-- = value;
                 value >>= 8;
             }
         } else {

--- a/src/BER.h
+++ b/src/BER.h
@@ -574,7 +574,8 @@ public:
             stream.write(0x80 | _size - 1);
             unsigned int length = _length;
             for (uint8_t index = 0; index < _size - 1; ++index) {
-                stream.write(static_cast<uint8_t>((length >> (((_size-1) - index - 1) << 3)) & 0xFF));
+                stream.write(length >> ((_size - index - 2) << 3));
+
             }
         } else {
             stream.write(_length);

--- a/src/BER.h
+++ b/src/BER.h
@@ -597,8 +597,6 @@ public:
                 _length += stream.read();
             }
             _size++;
-        } else {
-            _size = 1;
         }
     }
 #else
@@ -646,6 +644,7 @@ public:
                 _length <<= 8;
                 _length += *pointer++;
             }
+            _size++;
         }
         return pointer;
     }

--- a/src/BER.h
+++ b/src/BER.h
@@ -573,7 +573,7 @@ public:
         if (_length > 0x7F) {
             stream.write(0x80 | _size - 1);
             unsigned int length = _length;
-            for (uint8_t index = 0; index < (_size-1); ++index) {
+            for (uint8_t index = 0; index < _size - 1; ++index) {
                 stream.write(static_cast<uint8_t>((length >> (((_size-1) - index - 1) << 3)) & 0xFF));
             }
         } else {


### PR DESCRIPTION
The encoding of the LENGTH on the SNMP packet was wrong for packets with lengths more than 127 bytes (0x7F). This pull request fixes that.