### PR TITLE
Allow specificTrap to be higher than 255

### DIFF
--- a/src/BER.h
+++ b/src/BER.h
@@ -156,7 +156,7 @@ struct Trap {
     /** Generic trap code. */
     uint8_t _genericTrap;
     /** Specific trap code. */
-    uint8_t _specificTrap;
+    uint32_t _specificTrap;
     /** Time elapsed since device startup. */
     uint32_t _timeStamp;
 };

--- a/src/SNMPMessage.h
+++ b/src/SNMPMessage.h
@@ -339,7 +339,7 @@ public:
      * @param generic Generic trap code.
      * @param specific Specific trap code.
      */
-    void setTrap(const uint8_t generic, const uint8_t specific = 0) {
+    void setTrap(const uint8_t generic, const uint32_t specific = 0) {
         _trap._genericTrap = generic;
         _trap._specificTrap = specific;
     }


### PR DESCRIPTION
The specificTrap field in SNMPv1 is defined as an INTEGER, which allows for values beyond the 8-bit range. This change updates the field type to uint32_t, enabling the library to represent any valid trap number as needed, including enterprise-specific traps with identifiers greater than 255.