### PR TITLE
Silence the C++ warnings

### DIFF
--- a/src/SNMPMessage.h
+++ b/src/SNMPMessage.h
@@ -115,16 +115,16 @@ public:
      */
     class OID {
     public:
-        static constexpr char *COLDSTART = "1.3.6.1.6.3.1.1.5.1";
-        static constexpr char *WARMSTART = "1.3.6.1.6.3.1.1.5.2";
-        static constexpr char *LINKDOWN = "1.3.6.1.6.3.1.1.5.3";
-        static constexpr char *LINKUP = "1.3.6.1.6.3.1.1.5.4";
-        static constexpr char *AUTHENTICATIONFAILURE = "1.3.6.1.6.3.1.1.5.5";
+        static constexpr const char *COLDSTART = "1.3.6.1.6.3.1.1.5.1";
+        static constexpr const char *WARMSTART = "1.3.6.1.6.3.1.1.5.2";
+        static constexpr const char *LINKDOWN = "1.3.6.1.6.3.1.1.5.3";
+        static constexpr const char *LINKUP = "1.3.6.1.6.3.1.1.5.4";
+        static constexpr const char *AUTHENTICATIONFAILURE = "1.3.6.1.6.3.1.1.5.5";
 
     private:
-        static constexpr char *SYSUPTIME = "1.3.6.1.2.1.1.3.0";
-        static constexpr char *SNMPTRAPOID = "1.3.6.1.6.3.1.1.4.1.0";
-        static constexpr char *SNMPTRAPENTERPRISE = "1.3.6.1.6.3.1.1.4.3.0";
+        static constexpr const char *SYSUPTIME = "1.3.6.1.2.1.1.3.0";
+        static constexpr const char *SNMPTRAPOID = "1.3.6.1.6.3.1.1.4.1.0";
+        static constexpr const char *SNMPTRAPENTERPRISE = "1.3.6.1.6.3.1.1.4.3.0";
 
         friend class Message;
     };


### PR DESCRIPTION
`constexpr` doesn't imply `const`?!?

This silences this warning:

```
.....libraries/SNMP/src/SNMPMessage.h:127:53: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
  127 |         static constexpr char *SNMPTRAPENTERPRISE = "1.3.6.1.6.3.1.1.4.3.0";
      |                                                     ^~~~~~~~~~~~~~~~~~~~~~~
```